### PR TITLE
Chanded From Authorization Header to Cookie

### DIFF
--- a/middlewares/AuthFilter.go
+++ b/middlewares/AuthFilter.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -46,20 +45,13 @@ func ValidateToken(tokenString string) (models.PublicUser, error) {
 
 func AuthFilter(context *gin.Context) {
 	// Get the token from the header
-	header := context.Request.Header.Get("Authorization")
-	if header == "" {
-		context.AbortWithStatusJSON(401, gin.H{"error": "Authorization header missing"})
+	cookie, err := context.Cookie("Authorization")
+	if err != nil {
+		context.AbortWithStatusJSON(401, gin.H{"error": "Please login"})
 		return
 	}
-	authHeader := strings.Split(context.Request.Header.Get("Authorization"), " ")
-	if len(authHeader) != 2 || authHeader[0] != "Bearer" {
-		context.AbortWithStatusJSON(401, gin.H{"error": "Authorization header format must be Bearer {token}"})
-		return
-	}
-
 	// Validate the token
-	token := authHeader[1]
-	claims, err := ValidateToken(token)
+	claims, err := ValidateToken(cookie)
 
 	if err != nil {
 		context.AbortWithStatusJSON(401, gin.H{"error": err.Error()})

--- a/routes/UserRoutes.go
+++ b/routes/UserRoutes.go
@@ -8,4 +8,5 @@ import (
 func UserRoutes(r *gin.Engine) {
 	r.POST("/api/users/register", services.CreateUser)
 	r.POST("/api/users/login", services.VerifyUser)
+	r.GET("/api/users/logout", services.LogoutUser)
 }

--- a/services/UserServices.go
+++ b/services/UserServices.go
@@ -59,7 +59,9 @@ func CreateUser(context *gin.Context) {
 		context.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	context.JSON(http.StatusCreated, gin.H{"message": "User Created Successfully", "token": token})
+	context.SetSameSite(http.SameSiteNoneMode)
+	context.SetCookie("Authorization", token, 3600*24*7, "", "", false, true)
+	context.JSON(http.StatusCreated, gin.H{"message": "User Created Successfully and Logged In"})
 }
 
 func VerifyUser(context *gin.Context) {
@@ -79,8 +81,17 @@ func VerifyUser(context *gin.Context) {
 			context.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		context.JSON(http.StatusAccepted, gin.H{"message": "User Verified", "token": token})
+		context.SetSameSite(http.SameSiteNoneMode)
+		context.SetCookie("Authorization", token, 3600*24*7, "", "", false, true)
+		context.JSON(http.StatusAccepted, gin.H{"message": "User Verified and Logged In"})
 	} else {
 		context.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "User Not Verified"})
 	}
+}
+
+func LogoutUser(context *gin.Context) {
+	context.Header("Content-Type", "application/json")
+	context.SetSameSite(http.SameSiteNoneMode)
+	context.SetCookie("Authorization", "", -1, "", "", false, true)
+	context.JSON(http.StatusOK, gin.H{"message": "User Logged Out"})
 }


### PR DESCRIPTION
Now we don't have to add header to every single request. Now we can just login and then the auth token will be saved in our cookie.